### PR TITLE
IE fix path parser

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -246,7 +246,13 @@ class Router {
       url = url.replace(new RegExp(b, 'i'), '') || '/'
     }
     parser.href = Router.canonicalizePath(url)
-    return parser
+    return {
+      hash: parser.hash,
+      pathname: (parser.pathname.charAt(0) === '/')
+        ? parser.pathname
+        : '/' + parser.pathname,
+      search: parser.search
+    }
   }
 
   static getPath(url) {


### PR DESCRIPTION
Return object that mimics anchor, but with pathname having a leading slash.

IE9-11 always omit the leading slash from anchor pathname.