### PR TITLE
Fixed a bug that it was taking Array.prototype functions as keys in loop.

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -186,19 +186,19 @@ export default class Router {
     let fewestMatchingSegments = Infinity
 
     for (const rn in this.routes) {
-	  if (this.routes.hasOwnProperty(rn)) {
-	    const r = this.routes[rn]
-	    if (r.matches(path)) {
-		  if (r.keys.length === 0) {
-		    return r
-		  } else if (fewestMatchingSegments === Infinity ||
-		    (r.keys.length < fewestMatchingSegments && r.keys[0].pattern !== '.*')) {
-		    fewestMatchingSegments = r.keys.length
-		    matchingRouteWithFewestDynamicSegments = r
-		  }
-	    }
-	  }
-	}
+      if (this.routes.hasOwnProperty(rn)) {
+        const r = this.routes[rn]
+        if (r.matches(path)) {
+          if (r.keys.length === 0) {
+            return r
+          } else if (fewestMatchingSegments === Infinity ||
+            (r.keys.length < fewestMatchingSegments && r.keys[0].pattern !== '.*')) {
+            fewestMatchingSegments = r.keys.length
+            matchingRouteWithFewestDynamicSegments = r
+          }
+        }
+      }
+    }
     return matchingRouteWithFewestDynamicSegments
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -187,17 +187,17 @@ export default class Router {
 
     for (const rn in this.routes) {
 	  if (this.routes.hasOwnProperty(rn)) {
-		  const r = this.routes[rn]
-		  if (r.matches(path)) {
-			if (r.keys.length === 0) {
-			  return r
-			} else if (fewestMatchingSegments === Infinity ||
-			  (r.keys.length < fewestMatchingSegments && r.keys[0].pattern !== '.*')) {
-			  fewestMatchingSegments = r.keys.length
-			  matchingRouteWithFewestDynamicSegments = r
-			}
+	    const r = this.routes[rn]
+	    if (r.matches(path)) {
+		  if (r.keys.length === 0) {
+		    return r
+		  } else if (fewestMatchingSegments === Infinity ||
+		    (r.keys.length < fewestMatchingSegments && r.keys[0].pattern !== '.*')) {
+		    fewestMatchingSegments = r.keys.length
+		    matchingRouteWithFewestDynamicSegments = r
 		  }
-		}
+	    }
+	  }
 	}
     return matchingRouteWithFewestDynamicSegments
   }

--- a/src/router.ts
+++ b/src/router.ts
@@ -186,18 +186,19 @@ export default class Router {
     let fewestMatchingSegments = Infinity
 
     for (const rn in this.routes) {
-      const r = this.routes[rn]
-      if (r.matches(path)) {
-        if (r.keys.length === 0) {
-          return r
-        } else if (fewestMatchingSegments === Infinity ||
-          (r.keys.length < fewestMatchingSegments && r.keys[0].pattern !== '.*')) {
-          fewestMatchingSegments = r.keys.length
-          matchingRouteWithFewestDynamicSegments = r
-        }
-      }
-    }
-
+	  if (this.routes.hasOwnProperty(rn)) {
+		  const r = this.routes[rn]
+		  if (r.matches(path)) {
+			if (r.keys.length === 0) {
+			  return r
+			} else if (fewestMatchingSegments === Infinity ||
+			  (r.keys.length < fewestMatchingSegments && r.keys[0].pattern !== '.*')) {
+			  fewestMatchingSegments = r.keys.length
+			  matchingRouteWithFewestDynamicSegments = r
+			}
+		  }
+		}
+	}
     return matchingRouteWithFewestDynamicSegments
   }
 


### PR DESCRIPTION
Added hasOwnProperty check in method Router.resolveRoute that matches predefined routes in for..in loop. 
This fixed a bug that it was taking Array.prototype functions as keys in loop.