### PR TITLE
add missing packages to package json; webpack config to point to node…

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -8,6 +8,9 @@
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-preset-es2017": "^6.22.0",
     "html-loader": "^0.4.5",
+    "knockout": "^3.4.2",
+    "ko-component-router": "^4.4.4",
+    "lodash-es": "^4.17.4",
     "toprogress": "^0.1.3",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.4.2"

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -35,10 +35,5 @@ module.exports = {
         loader: 'html-loader'
       }
     ]
-  },
-  resolve: {
-    alias: {
-      'ko-component-router': path.resolve(__dirname, '../dist/modules')
-    }
   }
 }


### PR DESCRIPTION
…_modules for ko-component-router so the person trying to run examples doesn't need to have ko-component-router built as well